### PR TITLE
Fixing typo in doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -142,7 +142,7 @@ TCPHCatalog = Catalog(dbs)
 ### Query the data
 
 ```python
->>> from my_catalog import MyCatalog
+>>> from my_catalog import TCPHCatalog
 >>> from neuralake.core import Filter
 >>> 
 >>> # Get part and supplier information


### PR DESCRIPTION
Would be nice if the examples were runnable so we could guarantee the doc examples work. 