### PR TITLE
Use sql builder to construct queries

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+extend-ignore =
+    # Handled by black
+    E501

--- a/client/neuralake/test/tables/test_deltalake_table.py
+++ b/client/neuralake/test/tables/test_deltalake_table.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -9,7 +8,6 @@ import pyarrow as pa
 import pytest
 
 from neuralake.core.tables.deltalake_table import (
-    DeltaCacheOptions,
     DeltalakeTable,
     Filter,
     fetch_df_by_partition,

--- a/client/neuralake/test/tables/test_util.py
+++ b/client/neuralake/test/tables/test_util.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pyarrow as pa
 import pytest
 
@@ -18,6 +20,7 @@ test_schema = pa.schema(
         ("int_col", pa.int64()),
         ("list_col", pa.list_(pa.int64())),
         ("list_str_col", pa.list_(pa.string())),
+        ("date_col", pa.timestamp("us", tz="UTC")),
     ]
 )
 
@@ -26,54 +29,64 @@ class TestUtil:
     @pytest.mark.parametrize(
         ("schema", "f", "expected"),
         [
-            (test_schema, Filter("int_col", "=", 123), "(int_col = 123)"),
-            (test_schema, Filter("int_col", "=", "123"), "(int_col = 123)"),
+            (test_schema, Filter("int_col", "=", 123), '"int_col"=123'),
+            (test_schema, Filter("int_col", "=", "123"), "\"int_col\"='123'"),
             # A tuple with a single element should not have a comma in SQL
-            (test_schema, Filter("int_col", "in", (1,)), "(int_col in (1))"),
-            (test_schema, Filter("int_col", "in", (1, 2)), "(int_col in (1, 2))"),
+            (test_schema, Filter("int_col", "in", (1,)), '"int_col" IN (1)'),
+            (test_schema, Filter("int_col", "in", (1, 2)), '"int_col" IN (1,2)'),
             (
                 test_schema,
                 Filter("int_col", "not in", (1, 2)),
-                "(int_col not in (1, 2))",
+                '"int_col" NOT IN (1,2)',
             ),
             # String columns should be handled to add single quotes
-            (test_schema, Filter("str_col", "=", "x"), "(str_col = 'x')"),
-            (test_schema, Filter("str_col", "in", ("val1",)), "(str_col in ('val1'))"),
+            (test_schema, Filter("str_col", "=", "x"), "\"str_col\"='x'"),
+            # Filtering using datetime columns
+            (
+                test_schema,
+                Filter("date_col", ">=", datetime(2024, 4, 5, tzinfo=timezone.utc)),
+                "\"date_col\">='2024-04-05T00:00:00+00:00'",
+            ),
+            (
+                test_schema,
+                Filter("str_col", "in", ("val1",)),
+                "\"str_col\" IN ('val1')",
+            ),
             (
                 test_schema,
                 Filter("str_col", "in", ("val1", "val2")),
-                "(str_col in ('val1', 'val2'))",
+                "\"str_col\" IN ('val1','val2')",
             ),
             (
                 test_schema,
                 Filter("str_col", "contains", "x'"),
-                "(str_col like '%x''%')",
+                "\"str_col\" LIKE '%x''%'",
             ),
             # Test list columns
             (
                 test_schema,
                 Filter("list_col", "includes", 1),
-                "(array_contains(list_col, 1))",
+                'array_contains("list_col",1)',
             ),
             (
                 test_schema,
                 Filter("list_str_col", "includes", "x"),
-                "(array_contains(list_str_col, 'x'))",
+                "array_contains(\"list_str_col\",'x')",
             ),
             (
                 test_schema,
                 Filter("list_col", "includes all", (1, 2, 3)),
-                "(array_contains(list_col, 1) and array_contains(list_col, 2) and array_contains(list_col, 3))",
+                'array_contains("list_col",1) AND array_contains("list_col",2) AND array_contains("list_col",3)',
             ),
             (
                 test_schema,
                 Filter("list_col", "includes any", (1, 2, 3)),
-                "(array_contains(list_col, 1) or array_contains(list_col, 2) or array_contains(list_col, 3))",
+                'array_contains("list_col",1) OR array_contains("list_col",2) OR array_contains("list_col",3)',
             ),
         ],
     )
     def test_filter_to_expr(self, schema: pa.Schema, f: Filter, expected: str):
-        assert filter_to_sql_expr(schema, f) == expected
+        assert str(filter_to_sql_expr(schema, f)) == expected
 
     def test_filter_to_expr_raises(self):
         with pytest.raises(ValueError) as e:
@@ -84,11 +97,11 @@ class TestUtil:
     @pytest.mark.parametrize(
         ("schema", "filters", "expected"),
         [
-            (test_schema, [[Filter("str_col", "=", "x")]], "((str_col = 'x'))"),
+            (test_schema, [[Filter("str_col", "=", "x")]], "\"str_col\"='x'"),
             (
                 test_schema,
                 [[Filter("str_col", "=", "x"), Filter("int_col", "=", 123)]],
-                "((str_col = 'x') and (int_col = 123))",
+                '"str_col"=\'x\' AND "int_col"=123',
             ),
             (
                 test_schema,
@@ -96,14 +109,26 @@ class TestUtil:
                     [Filter("str_col", "=", "x")],
                     [Filter("int_col", "=", 123), Filter("int_col", "<", 456)],
                 ],
-                "((str_col = 'x')) or ((int_col = 123) and (int_col < 456))",
+                '"str_col"=\'x\' OR ("int_col"=123 AND "int_col"<456)',
+            ),
+            (
+                test_schema,
+                # Ensures filters are properly nested and grouped
+                [
+                    [Filter("str_col", "=", "x")],
+                    [
+                        Filter("list_col", "includes any", (1, 2, 3)),
+                        Filter("list_col", "includes all", (1, 2, 3)),
+                    ],
+                ],
+                '"str_col"=\'x\' OR ((array_contains("list_col",1) OR array_contains("list_col",2) OR array_contains("list_col",3)) AND array_contains("list_col",1) AND array_contains("list_col",2) AND array_contains("list_col",3))',
             ),
         ],
     )
     def test_filters_to_sql_predicate(
         self, schema: pa.Schema, filters: NormalizedFilters, expected: str
     ):
-        assert filters_to_sql_predicate(schema, filters) == expected
+        assert str(filters_to_sql_predicate(schema, filters)) == expected
 
     @pytest.mark.parametrize(
         ("filters", "expected"),

--- a/client/neuralake/web_export.py
+++ b/client/neuralake/web_export.py
@@ -2,14 +2,10 @@ from neuralake.core.catalog.catalog import Catalog, Database
 from neuralake.core.tables.deltalake_table import DeltalakeTable
 from neuralake.core.tables.metadata import TableProtocol
 import json
-import tempfile
-import subprocess
 from pathlib import Path
-import os
 import sys
 import logging
 import shutil
-import importlib.resources
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stderr)
@@ -89,7 +85,7 @@ def export_and_generate_site(
     logger.info(f"Copying precompiled directory {precompiled_dir} to {output_path}")
     if not precompiled_dir.exists():
         raise FileNotFoundError(
-            f"Could not find precompiled directory. Make sure you're running from the project root or the package is properly installed."
+            "Could not find precompiled directory. Make sure you're running from the project root or the package is properly installed."
         )
 
     shutil.copytree(precompiled_dir, output_path, dirs_exist_ok=True)

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pyarrow==17.0.0",
     "ipython==8.5.0",
     "typing_extensions==4.13.2",
+    "pypika>=0.48.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Use a SQL query builder to construct datafusion queries so there is less chance of misuse through SQL injections. 

This adds a new dependency on `PyPika` which is used to construct the SQL queries. This is the only popular SQL builder I found that generates plain string SQL (instead of using parameterization).

This changes the behavior of some filters. Namely, filtering an int column by string will no longer work, e.g.
```
table(filters=[Filter('id', '=', '123')])
```
(it would have worked in the previous version because `'123'` is directly interpolated into the query string)