### PR TITLE
fixing typo in URL

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: datarepo
-site_url: https://datarepo.io
+site_url: https://data-repo.io
 repo_url: https://github.com/neuralinkcorp/datarepo/
 repo_name: neuralink/datarepo
 


### PR DESCRIPTION
it looks like the repo just underwent a name update, but this URL may have been written with the wrong domain. Some background research points to the correct domain name having a “-“ between “data" and “repo.io"