### PR TITLE
Adding CNAME to gh_pages to keep custom domain on redeploy

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -149,3 +149,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
           publish_branch: gh-pages
+          cname: data-repo.io


### PR DESCRIPTION
Resolves https://github.com/neuralinkcorp/datarepo/issues/27