### PR TITLE
fix(core): corrections in docstring and error msg

### DIFF
--- a/src/datarepo/core/catalog/catalog.py
+++ b/src/datarepo/core/catalog/catalog.py
@@ -20,7 +20,7 @@ class ModuleDatabase(Database):
         self.db = db
 
     def __getattr__(self, name: str):
-        # HACK: to maintain backwards compability when accessing module attributes
+        # HACK: to maintain backwards compatibility when accessing module attributes
         return self._get_table(name)
 
     def get_tables(self, show_deprecated: bool = False) -> dict[str, TableProtocol]:

--- a/src/datarepo/core/tables/parquet_table.py
+++ b/src/datarepo/core/tables/parquet_table.py
@@ -115,7 +115,7 @@ class ParquetTable(TableProtocol):
         table_metadata_args: dict[str, Any] | None = None,
     ):
         if not isinstance(partitioning_scheme, PartitioningScheme):
-            raise ValueError(f"Invalid parititioning scheme, got {partitioning_scheme}")
+            raise ValueError(f"Invalid partitioning scheme, got {partitioning_scheme}")
 
         self.name = name
         self.uri = uri


### PR DESCRIPTION
Corrected `compability` to `compatibility` in a docstring and `parititioning` to `partitioning` in a `ValueError` message.