### PR TITLE
Issue 25 | CI: mypy

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -61,7 +61,7 @@ jobs:
     
     - name: Run mypy
       run: |
-        #mypy src/datarepo
+        mypy src/datarepo
 
   build-and-publish:
     needs: [run-tests, code-quality]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ venv/
 site/
 
 docs/examples/web_catalog/
+
+.DS_Store

--- a/src/datarepo/core/catalog/catalog.py
+++ b/src/datarepo/core/catalog/catalog.py
@@ -7,12 +7,14 @@ from datarepo.core.tables.metadata import TableProtocol
 
 
 class Database(Protocol):
-    def get_tables(self, show_deprecated: bool = False) -> dict[str, TableProtocol]: ...
+    def get_tables(self, show_deprecated: bool = False) -> dict[str, TableProtocol]:
+        ...
 
     def tables(self, show_deprecated: bool = False) -> list[str]:
         return list(self.get_tables(show_deprecated).keys())
 
-    def table(self, name: str, *args: Any, **kwargs: Any) -> NlkDataFrame: ...
+    def table(self, name: str, *args: Any, **kwargs: Any) -> NlkDataFrame:
+        ...
 
 
 class ModuleDatabase(Database):

--- a/src/datarepo/core/tables/decorator.py
+++ b/src/datarepo/core/tables/decorator.py
@@ -6,6 +6,8 @@ from datarepo.core.tables.metadata import (
     TableMetadata,
     TableProtocol,
     TableSchema,
+    TableColumn,
+    TablePartition,
 )
 
 U = TypeVar("U")
@@ -36,22 +38,25 @@ class FunctionTable(TableProtocol):
 
         # Infer partitions from filters
         partitions = [
-            {
-                "column_name": filter.column,
-                "type_annotation": type(filter.value).__name__,
-                "value": filter.value,
-            }
+            TablePartition(
+                column_name=filter.column,
+                type_annotation=type(filter.value).__name__,
+                value=filter.value,
+            )
             for filter in filters
         ]
 
-        columns = None
+        columns = []
         if self.table_metadata.docs_args or not partitions:
             fallback_table = self(**self.table_metadata.docs_args)
             columns = [
-                {
-                    "name": key,
-                    "type": type.__str__(),
-                }
+                TableColumn(
+                    column=key,
+                    type=type.__str__(),
+                    readonly=True,
+                    filter_only=False,
+                    has_stats=False,
+                )
                 for key, type in fallback_table.collect_schema().items()
             ]
 

--- a/src/datarepo/core/tables/metadata.py
+++ b/src/datarepo/core/tables/metadata.py
@@ -45,7 +45,8 @@ class TableProtocol(Protocol):
     # Properties used to generate the web catalog & roapi config
     table_metadata: TableMetadata
 
-    def __call__(self, **kwargs: Dict[str, Any]) -> NlkDataFrame: ...
+    def __call__(self, **kwargs: Dict[str, Any]) -> NlkDataFrame:
+        ...
 
     def get_schema(self) -> TableSchema:
         """

--- a/src/datarepo/core/tables/util.py
+++ b/src/datarepo/core/tables/util.py
@@ -68,13 +68,14 @@ def get_storage_options(
 
     if boto3_session is not None:
         creds = boto3_session.get_credentials()
-        storage_options = {
-            **storage_options,
-            "aws_access_key_id": creds.access_key,
-            "aws_secret_access_key": creds.secret_key,
-            "aws_session_token": creds.token,
-            "aws_region": boto3_session.region_name,
-        }
+        if creds is not None:
+            storage_options = {
+                **storage_options,
+                "aws_access_key_id": creds.access_key,
+                "aws_secret_access_key": creds.secret_key,
+                "aws_session_token": creds.token or "",
+                "aws_region": boto3_session.region_name,
+            }
 
     # Storage options passed to delta-rs need to be not null
     storage_options = {k: v for k, v in storage_options.items() if v}
@@ -93,13 +94,14 @@ def get_pyarrow_filesystem_args(
 
     if boto3_session is not None:
         creds = boto3_session.get_credentials()
-        pyarrow_filesystem_args = {
-            **pyarrow_filesystem_args,
-            "access_key": creds.access_key,
-            "secret_key": creds.secret_key,
-            "session_token": creds.token,
-            "region": boto3_session.region_name,
-        }
+        if creds is not None:
+            pyarrow_filesystem_args = {
+                **pyarrow_filesystem_args,
+                "access_key": creds.access_key,
+                "secret_key": creds.secret_key,
+                "session_token": creds.token or "",
+                "region": boto3_session.region_name,
+            }
 
     pyarrow_filesystem_args = {
         k: v for k, v in pyarrow_filesystem_args.items() if v is not None

--- a/src/datarepo/export/static_site/build.py
+++ b/src/datarepo/export/static_site/build.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface  # type: ignore
 
 
 class StaticSiteBuildHook(BuildHookInterface):


### PR DESCRIPTION
## Summary

Fixes mypy type checking for repository.

Closes #25 


### Comments

flake8 is giving me warning for existing code in `main` branch. I'm not sure if it should be fixed within this PR or not

```shell
src/datarepo/core/__init__.py:1:1: F401 'datarepo.core.catalog.Database' imported but unused
src/datarepo/core/__init__.py:1:1: F401 'datarepo.core.catalog.ModuleDatabase' imported but unused
src/datarepo/core/catalog/__init__.py:1:1: F401 'datarepo.core.catalog.catalog.Database' imported but unused
src/datarepo/core/catalog/__init__.py:1:1: F401 'datarepo.core.catalog.catalog.ModuleDatabase' imported but unused
src/datarepo/core/tables/parquet_table.py:72:1: C901 '_filter_to_expr' is too complex (13)
src/datarepo/export/web.py:5:1: F401 'tempfile' imported but unused
src/datarepo/export/web.py:6:1: F401 'subprocess' imported but unused
src/datarepo/export/web.py:8:1: F401 'os' imported but unused
src/datarepo/export/web.py:12:1: F401 'importlib.resources' imported but unused
src/datarepo/export/web.py:92:13: F541 f-string is missing placeholders
src/datarepo/export/web.py:92:128: E501 line too long (137 > 127 characters)
```