### PR TITLE
Issue #31 | Static site: configurable url for catalog to jupyterhub

### DIFF
--- a/src/datarepo/core/__init__.py
+++ b/src/datarepo/core/__init__.py
@@ -1,4 +1,4 @@
-from datarepo.core.catalog import Catalog, Database, ModuleDatabase
+from datarepo.core.catalog import Catalog, Database, ModuleDatabase, CatalogMetadata
 from datarepo.core.dataframe import NlkDataFrame
 from datarepo.core.tables import (
     DeltaCacheOptions,
@@ -18,6 +18,7 @@ __all__ = [
     "ParquetTable",
     "NlkDataFrame",
     "Catalog",
+    "CatalogMetadata",
     "table",
     "PartitioningScheme",
     "Partition",

--- a/src/datarepo/core/catalog/__init__.py
+++ b/src/datarepo/core/catalog/__init__.py
@@ -1,3 +1,8 @@
-from datarepo.core.catalog.catalog import Catalog, Database, ModuleDatabase
+from datarepo.core.catalog.catalog import (
+    Catalog,
+    Database,
+    ModuleDatabase,
+    CatalogMetadata,
+)
 
-__all__ = ["Catalog", "Database", "ModuleDatabase"]
+__all__ = ["Catalog", "Database", "ModuleDatabase", "CatalogMetadata"]

--- a/src/datarepo/core/catalog/catalog.py
+++ b/src/datarepo/core/catalog/catalog.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from types import ModuleType
-from typing import Any, Protocol, cast
+from typing import Any, Optional, Protocol, cast
 import warnings
 
 from datarepo.core.dataframe import NlkDataFrame
@@ -182,16 +183,38 @@ class DatabaseWithGlobalArgs(Database):
         return self.db.table(name, *args, **new_kwargs)
 
 
+@dataclass
+class CatalogMetadata:
+    """Metadata for catalog."""
+
+    jupyterhub_url: str | None = None
+
+
 class Catalog:
     """A catalog that manages multiple databases and provides access to their tables."""
 
-    def __init__(self, dbs: dict[str, Database]):
+    def __init__(
+        self, dbs: dict[str, Database], metadata: Optional[CatalogMetadata] = None
+    ):
         """Initialize the Catalog.
+
+        Example usage:
+            ``` py
+            from datarepo.core import Catalog, CatalogMetadata
+            catalog = Catalog(
+                dbs={
+                    "my_db": ModuleDatabase(my_database_module),
+                },
+                metadata=CatalogMetadata(jupyterhub_url="https://jupyterhub.example.com")
+            )
+            ```
 
         Args:
             dbs (dict[str, Database]): A dictionary of database names and their corresponding Database objects.
+            metadata (Optional[CatalogMetadata], optional): Metadata for the catalog. Defaults to None.
         """
         self._dbs = dbs
+        self._metadata = metadata or CatalogMetadata()
         self._global_args: dict[str, Any] | None = None
 
     def set_global_args(self, global_args: dict[str, Any]) -> None:

--- a/src/datarepo/export/static_site/src/lib/types.ts
+++ b/src/datarepo/export/static_site/src/lib/types.ts
@@ -30,8 +30,13 @@ export interface ExportedDatabase {
   tables: ExportedTable[]
 }
 
+export interface ExportedCatalogMetadata {
+  jupyterhub_url?: string | null
+}
+
 export interface ExportedCatalog {
   name: string
+  metadata: ExportedCatalogMetadata | null
   databases: ExportedDatabase[]
 }
 

--- a/src/datarepo/export/static_site/src/pages/index.tsx
+++ b/src/datarepo/export/static_site/src/pages/index.tsx
@@ -88,7 +88,15 @@ export default function RootPage () {
           <Flex flexGrow='1' py='2' justify='end' align='center'>
             <Button
               variant='soft'
-              onClick={() => window.open("")}
+              onClick={() => {
+                const catalog = datarepo.catalogs.find(c => c.name === catalogKey)
+                const jupyterhubUrl = catalog?.metadata?.jupyterhub_url
+                if (jupyterhubUrl) {
+                  window.open(jupyterhubUrl, '_blank')
+                } else {
+                  console.warn('No JupyterHub URL found for the selected catalog.')
+                }
+              }}
             >
               <ExternalLinkIcon /> Run on JupyterHub
             </Button>

--- a/src/datarepo/export/web.py
+++ b/src/datarepo/export/web.py
@@ -67,6 +67,22 @@ def export_database(name: str, database: Database):
     }
 
 
+def export_catalog_metadata(catalog: Catalog):
+    """Export catalog metadata to a dictionary format.
+
+    Args:
+        catalog (Catalog): Catalog to export metadata from.
+
+    Returns:
+        dict[str, Any]: A dictionary containing the catalog's metadata,
+        including JupyterHub URL if available.
+    """
+    metadata = catalog._metadata
+    return {
+        "jupyterhub_url": metadata.jupyterhub_url if metadata else None,
+    }
+
+
 def export_catalog(name: str, catalog: Catalog):
     """Export a catalog to a dictionary format suitable for web catalog generation.
 
@@ -80,6 +96,7 @@ def export_catalog(name: str, catalog: Catalog):
     """
     return {
         "name": name,
+        "metadata": export_catalog_metadata(catalog),
         "databases": [export_database(key, catalog.db(key)) for key in catalog.dbs()],
     }
 


### PR DESCRIPTION
## Summary

Added configurable url link for catalog to jupyterhub.

Metadata is now exported to `data.json` and handled by static website pages.

### Example
```python
from datarepo.core import Catalog, CatalogMetadata
catalog = Catalog(
    dbs={
        "my_db": ...
    },
    metadata=CatalogMetadata(jupyterhub_url="https://jupyterhub.example.com")
)
```

Closes #31