### PR TITLE
Issue #39 | ClickhouseTable

### DIFF
--- a/src/datarepo/core/__init__.py
+++ b/src/datarepo/core/__init__.py
@@ -9,6 +9,8 @@ from datarepo.core.tables import (
     PartitioningScheme,
     TableMetadata,
     TableProtocol,
+    ClickHouseTable,
+    ClickHouseTableConfig,
     table,
 )
 
@@ -25,4 +27,6 @@ __all__ = [
     "Filter",
     "TableMetadata",
     "TableProtocol",
+    "ClickHouseTable",
+    "ClickHouseTableConfig",
 ]

--- a/src/datarepo/core/tables/__init__.py
+++ b/src/datarepo/core/tables/__init__.py
@@ -5,6 +5,7 @@ from datarepo.core.tables.deltalake_table import (
 )
 from datarepo.core.tables.metadata import TableMetadata, TableProtocol, TableSchema
 from datarepo.core.tables.parquet_table import ParquetTable
+from datarepo.core.tables.clickhouse_table import ClickHouseTable, ClickHouseTableConfig
 from datarepo.core.tables.util import (
     DeltaRoapiOptions,
     Filter,
@@ -26,4 +27,6 @@ __all__ = [
     "TableSchema",
     "DeltaRoapiOptions",
     "RoapiOptions",
+    "ClickHouseTable",
+    "ClickHouseTableConfig",
 ]

--- a/src/datarepo/core/tables/clickhouse_table.py
+++ b/src/datarepo/core/tables/clickhouse_table.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union, cast
+
+import logging
+import polars as pl
+import pyarrow as pa
+
+from datarepo.core.dataframe import NlkDataFrame
+from datarepo.core.tables.filters import Filter, InputFilters, normalize_filters
+from datarepo.core.tables.metadata import (
+    TableColumn,
+    TableMetadata,
+    TablePartition,
+    TableProtocol,
+    TableSchema,
+)
+from datarepo.core.tables.util import RoapiOptions
+from datarepo.core.tables.util import format_value_for_sql
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ClickHouseTableConfig:
+    """Configuration for connecting to ClickHouse."""
+
+    host: str
+    port: int = 8443
+    username: Optional[str] = None
+    password: Optional[str] = None
+    database: str = "default"
+    secure: bool = True
+    verify: bool = True
+    settings: Dict[str, Any] = field(default_factory=dict)
+
+
+class ClickHouseTable(TableProtocol):
+    """A table implementation that reads data from ClickHouse."""
+
+    def __init__(
+        self,
+        name: str,
+        schema: pa.Schema,
+        config: ClickHouseTableConfig,
+        description: str = "",
+        docs_filters: List[Filter] | None = None,
+        docs_columns: Optional[List[str]] = None,
+        roapi_opts: RoapiOptions | None = None,
+        unique_columns: Optional[List[str]] = None,
+        table_metadata_args: Optional[Dict[str, Any]] = None,
+        stats_cols: Optional[List[str]] = None,
+    ):
+        """Initialize the ClickHouseTable.
+
+        Example usage:
+            ```python
+            from datarepo.core.tables import ClickHouseTable, ClickHouseTableConfig
+
+            config = ClickHouseTableConfig(
+                host="localhost",
+                port=8443,
+                username="user",
+                password="password",
+                database="default",
+                secure=True,
+                verify=True,
+                settings={"max_result_rows": 1000}
+            )
+
+            table = ClickHouseTable(
+                name="my_table",
+                schema=pa.schema(
+                    [
+                        ("implant_id", pa.int64()),
+                        ("date", pa.string()),
+                        ("uniq", pa.string()),
+                        ("value", pa.int64()),
+                    ]
+                ),
+                config=config,
+                description="My ClickHouse table",
+                docs_filters=[...],
+                docs_columns=[...],
+                unique_columns=["uniq"],
+                table_metadata_args={"answer": "42"},
+                stats_cols=["implant_id"]
+            )
+            ```
+
+        Args:
+            name: Name of the table in ClickHouse
+            schema: Schema of the table
+            config: Configuration for connecting to ClickHouse
+            description: Description of the table for documentation
+            docs_filters: Filters to show in documentation
+            docs_columns: Columns to show in documentation
+            roapi_opts: Options for ROAPI integration
+            unique_columns: Columns to use for deduplication
+            table_metadata_args: Additional metadata arguments
+            stats_cols: Statistics columns, used to define columns that have statistics
+        """
+        self.name = name
+        self.schema = schema
+        self.config = config
+        self.unique_columns = unique_columns or []
+        self.docs_filters = docs_filters or []
+        self.docs_columns = docs_columns
+        self.stats_cols = stats_cols or []
+        self.client = None
+
+        self.table_metadata = TableMetadata(
+            table_type="CLICKHOUSE",
+            description=description,
+            docs_args={"filters": self.docs_filters, "columns": self.docs_columns},
+            roapi_opts=roapi_opts or RoapiOptions(),
+            **(table_metadata_args or {}),
+        )
+
+    def get_schema(self) -> TableSchema:
+        """Generate and return the schema of the table, including columns.
+
+        Returns:
+            TableSchema: table schema containing column information.
+        """
+        schema = self.schema
+
+        columns = [
+            TableColumn(
+                column=name,
+                type=str(schema.field(name).type),
+                readonly=False,
+                filter_only=False,
+                has_stats=name in self.stats_cols,
+            )
+            for name in schema.names
+        ]
+
+        return TableSchema(
+            partitions=[],  # Clickhouse does not have partitions exposed in schema.
+            columns=columns,
+        )
+
+    def _build_query(
+        self,
+        filters: InputFilters | None = None,
+        columns: Optional[List[str]] = None,
+    ) -> str:
+        """Build a SQL query for the ClickHouse table.
+
+        Args:
+            filters (InputFilters, optional): Filters to apply to the query. Defaults to None.
+            columns (Optional[List[str]], optional): Columns to select in the query. Defaults to None.
+
+        Returns:
+            str: SQL query string to select data from the ClickHouse table.
+        """
+        column_expr = "*"
+        if columns:
+            valid_columns = [c for c in columns if c in self.schema.names]
+            if valid_columns:
+                column_expr = ", ".join(f"`{c}`" for c in valid_columns)
+            else:
+                logger.warning(
+                    f"No valid columns provided for table {self.name}. Using '*' to select all columns."
+                )
+
+        # Build WHERE clause from filters if provided
+        where_clause = ""
+        if filters:
+            normalized_filters = normalize_filters(filters)
+            filter_expressions = []
+
+            for filter_set in normalized_filters:
+                set_expressions = []
+                for f in filter_set:
+                    if f.operator == "=":
+                        set_expressions.append(
+                            f"`{f.column}` = {format_value_for_sql(f.value)}"
+                        )
+                    elif f.operator == "!=":
+                        set_expressions.append(
+                            f"`{f.column}` != {format_value_for_sql(f.value)}"
+                        )
+                    elif f.operator == ">":
+                        set_expressions.append(
+                            f"`{f.column}` > {format_value_for_sql(f.value)}"
+                        )
+                    elif f.operator == "<":
+                        set_expressions.append(
+                            f"`{f.column}` < {format_value_for_sql(f.value)}"
+                        )
+                    elif f.operator == ">=":
+                        set_expressions.append(
+                            f"`{f.column}` >= {format_value_for_sql(f.value)}"
+                        )
+                    elif f.operator == "<=":
+                        set_expressions.append(
+                            f"`{f.column}` <= {format_value_for_sql(f.value)}"
+                        )
+                    elif f.operator == "in":
+                        values = ", ".join(
+                            format_value_for_sql(v) for v in cast(list, f.value)
+                        )
+                        set_expressions.append(f"`{f.column}` IN ({values})")
+                    elif f.operator == "not in":
+                        values = ", ".join(
+                            format_value_for_sql(v) for v in cast(list, f.value)
+                        )
+                        set_expressions.append(f"`{f.column}` NOT IN ({values})")
+                    elif f.operator in [
+                        "contains",
+                        "includes",
+                        "includes any",
+                        "includes all",
+                    ]:
+                        set_expressions.append(
+                            f"`{f.column}` LIKE {format_value_for_sql(f.value)}"
+                        )
+
+                if set_expressions:
+                    filter_expressions.append("(" + " AND ".join(set_expressions) + ")")
+
+            if filter_expressions:
+                where_clause = "WHERE " + " OR ".join(filter_expressions)
+
+        return f"SELECT {column_expr} FROM `{self.config.database}`.`{self.name}` {where_clause}"
+
+    def __call__(  # type: ignore[override]
+        self,
+        filters: InputFilters | None = None,
+        columns: List[str] | None = None,
+        **kwargs: Dict[str, Any],
+    ) -> NlkDataFrame:
+        """Query data from the ClickHouse table.
+
+        Example usage:
+            ``` py
+            from datarepo.core.tables import ClickHouseTable, ClickHouseTableConfig
+            config = ClickHouseTableConfig(...)
+            table = ClickHouseTable(...)
+            df = table(filters=[Filter("implant_id", "=", 123)], columns=["date", "value"])
+            ```
+
+        Args:
+            filters: Filters to apply to the data.
+            columns: Columns to select from the table.
+            **kwargs: Additional arguments.
+
+        Returns:
+            NlkDataFrame: A lazy Polars DataFrame with the requested data.
+        """
+        query = self._build_query(filters, columns)
+
+        # clickhouse connection uri
+        uri = f"clickhouse://{self.config.username}:{self.config.password}@{self.config.host}:{self.config.port}/{self.config.database}"
+
+        # use polars read database_uri to read the result of the query
+        df = pl.read_database_uri(
+            query=query,
+            uri=uri,
+            engine="connectorx",
+        )
+
+        return df.lazy()

--- a/src/datarepo/core/tables/util.py
+++ b/src/datarepo/core/tables/util.py
@@ -270,3 +270,30 @@ def value_to_sql_expr(value: Any, value_type: pa.DataType) -> str:
 def escape_str_for_sql(value: str) -> str:
     """Escape a string for use in a SQL query."""
     return value.replace("'", "''")
+
+
+def format_value_for_sql(value: Any) -> str:
+    """Format a value for use in a SQL query.
+
+    Args:
+        value: The value to format.
+
+    Returns:
+        A string representation of the value suitable for SQL.
+    """
+    if value is None:
+        return "NULL"
+    elif isinstance(value, str):
+        # Escape single quotes
+        escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+    elif isinstance(value, bool):
+        return "1" if value else "0"
+    elif isinstance(value, (int, float)):
+        return str(value)
+    elif isinstance(value, (list, tuple)):
+        return ", ".join(format_value_for_sql(v) for v in value)
+    else:
+        # For other types, convert to string and treat as string
+        escaped = str(value).replace("'", "''")
+        return f"'{escaped}'"

--- a/test/roapi/data/database.py
+++ b/test/roapi/data/database.py
@@ -7,6 +7,8 @@ from datarepo.core import (
     ParquetTable,
     Partition,
     PartitioningScheme,
+    ClickHouseTable,
+    ClickHouseTableConfig,
     table,
 )
 from datarepo.core.tables.util import RoapiOptions
@@ -50,4 +52,16 @@ test_delta_table_override_name = DeltalakeTable(
     schema=pa.schema([]),
     uri="s3://bucket/data/",
     roapi_opts=RoapiOptions(override_name="new_name"),
+)
+
+test_clickhouse_table = ClickHouseTable(
+    name="test_clickhouse_table",
+    schema=pa.schema([]),
+    config=ClickHouseTableConfig(
+        host="localhost",
+        port=8443,
+        username="user",
+        password="password",
+        database="default"
+    )
 )

--- a/test/roapi/test_roapi.py
+++ b/test/roapi/test_roapi.py
@@ -56,6 +56,15 @@ class TestRoapi(unittest.TestCase):
 
         assert result == [
             {
+                'name': 'database_test_clickhouse_table',
+                'option': {
+                    'format': 'clickhouse',
+                    'table': 'test_clickhouse_table',
+                    'use_memory_table': False,
+                },
+                'uri': 'clickhouse://user:password@localhost:8443/default',
+            },
+            {
                 "name": "database_test_delta_table",
                 "uri": "s3://bucket/data/",
                 "option": {"format": "delta", "use_memory_table": False},

--- a/test/tables/test_clickhouse_table.py
+++ b/test/tables/test_clickhouse_table.py
@@ -1,0 +1,195 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import polars as pl
+import pyarrow as pa
+
+from datarepo.core.tables.clickhouse_table import ClickHouseTable, ClickHouseTableConfig
+from datarepo.core.tables.filters import Filter
+from datarepo.core.tables.metadata import TableSchema
+
+
+class TestClickHouseTable:
+    @pytest.fixture
+    def clickhouse_config(self):
+        """Create a test ClickHouseTableConfig."""
+        return ClickHouseTableConfig(
+            host="localhost",
+            port=8443,
+            username="test_user",
+            password="test_password",
+            database="test_db",
+        )
+
+    @pytest.fixture
+    def clickhouse_table(self, clickhouse_config):
+        """Create a test ClickHouseTable."""
+        return ClickHouseTable(
+            name="test_table",
+            schema=pa.schema(
+                [
+                    ("implant_id", pa.int64()),
+                    ("date", pa.string()),
+                    ("value", pa.int64()),
+                    ("str_value", pa.string()),
+                    ("arr_value", pa.list_(pa.int64())),
+                ]
+            ),
+            config=clickhouse_config,
+            description="Test ClickHouse table",
+            unique_columns=["implant_id", "date"],
+        )
+
+    def test_get_schema(self, clickhouse_table: ClickHouseTable):
+        """Test that get_schema returns the correct schema."""
+        schema = clickhouse_table.get_schema()
+
+        assert isinstance(schema, TableSchema)
+        assert len(schema.columns) == 5
+        assert schema.columns[0]["column"] == "implant_id"
+        assert schema.columns[0]["type"] == "int64"
+        assert schema.columns[0]["has_stats"] is False
+        assert schema.partitions == []
+
+    def test_build_query_no_filters(self, clickhouse_table: ClickHouseTable):
+        """Test query building without filters."""
+        query = clickhouse_table._build_query()
+
+        expected_query = "SELECT * FROM `test_db`.`test_table` "
+        assert query == expected_query
+
+    def test_build_query_with_columns(self, clickhouse_table: ClickHouseTable):
+        """Test query building with specific columns."""
+        query = clickhouse_table._build_query(columns=["implant_id", "value"])
+
+        expected_query = "SELECT `implant_id`, `value` FROM `test_db`.`test_table` "
+        assert query == expected_query
+
+    def test_build_query_with_filters(self, clickhouse_table: ClickHouseTable):
+        """Test query building with filters."""
+        filters = [Filter("implant_id", "=", 1)]
+        query = clickhouse_table._build_query(filters=filters)
+
+        expected_query = "SELECT * FROM `test_db`.`test_table` WHERE (`implant_id` = 1)"
+        assert query == expected_query
+
+    def test_build_query_with_multiple_filters(self, clickhouse_table: ClickHouseTable):
+        """Test query building with multiple filters."""
+        filters = [
+            [Filter("implant_id", "=", 1), Filter("date", "=", "2023-01-01")],
+            [Filter("value", ">", 50)],
+        ]
+        query = clickhouse_table._build_query(filters=filters)
+
+        expected_query = "SELECT * FROM `test_db`.`test_table` WHERE (`implant_id` = 1 AND `date` = '2023-01-01') OR (`value` > 50)"
+        assert query == expected_query
+
+    @pytest.mark.parametrize(
+        "operator,value,expected_condition",
+        [
+            ("=", 1, "`implant_id` = 1"),
+            ("!=", 1, "`implant_id` != 1"),
+            (">", 1, "`implant_id` > 1"),
+            ("<", 1, "`implant_id` < 1"),
+            (">=", 1, "`implant_id` >= 1"),
+            ("<=", 1, "`implant_id` <= 1"),
+            ("in", [1, 2, 3], "`implant_id` IN (1, 2, 3)"),
+            ("not in", [1, 2, 3], "`implant_id` NOT IN (1, 2, 3)"),
+            ("contains", "%test%", "`str_value` LIKE '%test%'"),
+        ],
+    )
+    def test_filter_operators(
+        self,
+        clickhouse_table: ClickHouseTable,
+        operator: str,
+        value: str,
+        expected_condition: str,
+    ):
+        """Test different filter operators."""
+        column = "str_value" if operator == "contains" else "implant_id"
+        filters = [Filter(column, operator, value)]
+
+        query = clickhouse_table._build_query(filters=filters)
+        expected_query = (
+            f"SELECT * FROM `test_db`.`test_table` WHERE ({expected_condition})"
+        )
+        assert query == expected_query
+
+    @patch("polars.read_database_uri")
+    def test_call_with_no_filters(
+        self, mock_read_database_uri, clickhouse_table: ClickHouseTable
+    ):
+        """Test calling the table with no filters."""
+        mock_df = pl.DataFrame(
+            {
+                "implant_id": [1, 2, 3],
+                "date": ["2023-01-01", "2023-01-02", "2023-01-03"],
+                "value": [10, 20, 30],
+            }
+        )
+        mock_read_database_uri.return_value = mock_df
+
+        result = clickhouse_table().collect()
+
+        mock_read_database_uri.assert_called_once()
+        call_args = mock_read_database_uri.call_args[1]
+        assert call_args["query"] == "SELECT * FROM `test_db`.`test_table` "
+        assert (
+            call_args["uri"]
+            == "clickhouse://test_user:test_password@localhost:8443/test_db"
+        )
+        assert call_args["engine"] == "connectorx"
+
+        assert result.equals(mock_df)
+
+    @patch("polars.read_database_uri")
+    def test_call_with_filters_and_columns(
+        self, mock_read_database_uri: str, clickhouse_table: ClickHouseTable
+    ):
+        """Test calling the table with filters and columns."""
+        mock_df = pl.DataFrame(
+            {
+                "implant_id": [1],
+                "value": [10],
+            }
+        )
+        mock_read_database_uri.return_value = mock_df
+
+        filters = [Filter("implant_id", "=", 1)]
+        columns = ["implant_id", "value"]
+        result = clickhouse_table(filters=filters, columns=columns).collect()
+
+        mock_read_database_uri.assert_called_once()
+        call_args = mock_read_database_uri.call_args[1]
+        assert (
+            call_args["query"]
+            == "SELECT `implant_id`, `value` FROM `test_db`.`test_table` WHERE (`implant_id` = 1)"
+        )
+        assert (
+            call_args["uri"]
+            == "clickhouse://test_user:test_password@localhost:8443/test_db"
+        )
+        assert call_args["engine"] == "connectorx"
+
+        assert result.equals(mock_df)
+
+    @patch("polars.read_database_uri")
+    def test_call_handles_empty_results(
+        self, mock_read_database_uri: str, clickhouse_table: ClickHouseTable
+    ):
+        """Test that the table handles empty results correctly."""
+        mock_df = pl.DataFrame(
+            schema={
+                "implant_id": pl.Int64,
+                "date": pl.Utf8,
+                "value": pl.Int64,
+            }
+        )
+        mock_read_database_uri.return_value = mock_df
+
+        filters = [Filter("implant_id", "=", 999)]
+        result = clickhouse_table(filters=filters).collect()
+
+        assert result.height == 0
+        assert "implant_id" in result.columns
+        assert "date" in result.columns
+        assert "value" in result.columns


### PR DESCRIPTION
## Summary

Add support for ClickhouseTable

TODOs:
- [x] `ClickhouseTable` class and implementation
- [x] ROAPI support via connectionx
- [x] functional tests

```python
from datarepo.core.tables import ClickHouseTable, ClickHouseTableConfig

config = ClickHouseTableConfig(
    host="localhost",
    port=8443,
    username="user",
    password="password",
    database="default"
)

table = ClickHouseTable(
    name="my_table",
    schema=pa.schema(
        [
            ("implant_id", pa.int64()),
            ("date", pa.string()),
            ("uniq", pa.string()),
            ("value", pa.int64()),
        ]
    ),
    config=config,
    description="My ClickHouse table",
    docs_filters=[...],
    docs_columns=[...],
    unique_columns=["uniq"],
    table_metadata_args={"answer": "42"},
    stats_cols=["implant_id"]
)
```

Closes #39 