### PR TITLE
Issue #38 | Codegen: add optional package name for catalog

### DIFF
--- a/src/datarepo/core/catalog/catalog.py
+++ b/src/datarepo/core/catalog/catalog.py
@@ -194,7 +194,10 @@ class Catalog:
     """A catalog that manages multiple databases and provides access to their tables."""
 
     def __init__(
-        self, dbs: dict[str, Database], metadata: Optional[CatalogMetadata] = None
+        self,
+        dbs: dict[str, Database],
+        package_name: Optional[str] = None,
+        metadata: Optional[CatalogMetadata] = None,
     ):
         """Initialize the Catalog.
 
@@ -205,15 +208,18 @@ class Catalog:
                 dbs={
                     "my_db": ModuleDatabase(my_database_module),
                 },
+                package_name="my_package",
                 metadata=CatalogMetadata(jupyterhub_url="https://jupyterhub.example.com")
             )
             ```
 
         Args:
             dbs (dict[str, Database]): A dictionary of database names and their corresponding Database objects.
+            package_name (str | None, optional): The name of the package that contains the catalog. Defaults to None.
             metadata (Optional[CatalogMetadata], optional): Metadata for the catalog. Defaults to None.
         """
         self._dbs = dbs
+        self._package_name = package_name
         self._metadata = metadata or CatalogMetadata()
         self._global_args: dict[str, Any] | None = None
 

--- a/src/datarepo/export/static_site/src/lib/codegen.ts
+++ b/src/datarepo/export/static_site/src/lib/codegen.ts
@@ -97,7 +97,7 @@ export function genTableCode({ catalog, database, table, formatSqlFilter }: GenT
 
   const formattedParams = formatPythonTupleOrParams(params)
 
-  let retTable = `from datarepo_catalogs import ${catalog.name}\n`
+  let retTable = `from ${catalog.package_name || 'datarepo_catalogs'} import ${catalog.name}\n`
 
   retTable += `from datarepo.core import Filter\n`
 

--- a/src/datarepo/export/static_site/src/lib/types.ts
+++ b/src/datarepo/export/static_site/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface ExportedCatalogMetadata {
 
 export interface ExportedCatalog {
   name: string
+  package_name: string | null
   metadata: ExportedCatalogMetadata | null
   databases: ExportedDatabase[]
 }

--- a/src/datarepo/export/web.py
+++ b/src/datarepo/export/web.py
@@ -96,6 +96,7 @@ def export_catalog(name: str, catalog: Catalog):
     """
     return {
         "name": name,
+        "package_name": catalog._package_name,
         "metadata": export_catalog_metadata(catalog),
         "databases": [export_database(key, catalog.db(key)) for key in catalog.dbs()],
     }


### PR DESCRIPTION
### Summary

Adds optional package name field for `Catalog` that is used for codegen for snippets.

### Details

```python
  from datarepo.core import Catalog, CatalogMetadata
  catalog = Catalog(
      dbs={
          "my_db": ModuleDatabase(my_database_module),
      },
      package_name="my_package",
      ...
  )
```