### PR TITLE
Issue #42 | DeltaTable: versioned tables

### DIFF
--- a/src/datarepo/core/tables/metadata.py
+++ b/src/datarepo/core/tables/metadata.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Protocol, TypedDict
+from typing import Any, Dict, Protocol, TypedDict, List
 
 from datarepo.core.dataframe.frame import NlkDataFrame
 from datarepo.core.tables.util import RoapiOptions
@@ -52,5 +52,34 @@ class TableProtocol(Protocol):
     def get_schema(self) -> TableSchema:
         """
         Returns the schema of the table, used to generate the web catalog.
+        """
+        ...
+
+
+class VersionedTableProtocol(TableProtocol):
+    """A versioned table."""
+
+    def add_version(self, version: str, **kwargs: Dict[str, Any]) -> None:
+        """Add a new version of the table.
+
+        Args:
+            version (str): The version number of the table.
+            **kwargs: Additional arguments to pass for the version.
+        """
+        ...
+
+    def change_version(self, version: str):
+        """Change the current version of the table.
+
+        Args:
+            version (str): The version of the table.
+        """
+        ...
+
+    def get_versions(self) -> List[str]:  # type: ignore[empty-body]
+        """Get all versions of the table.
+
+        Returns:
+            list[str]: Versions of the table.
         """
         ...


### PR DESCRIPTION
### Summary

Adds support for versions for DeltaTable.

### Details

Versions are supported via `VersionedTableProtocol`. For different tables versions would mean different things. For example for DeltaTable it will be combination of uri and schema. This PR implements versions for DeltaTable as per original issue request.

Example
```python
table = DeltalakeTable(
    name="my_delta_table",
    schema=pa.schema(
        [
            ("implant_id", pa.int64()),
            ("date", pa.string()),
            ("uniq", pa.string()),
            ("value", pa.int64()),
        ]
    ),
    uri=".../somepath/v1/",
    ...
)

new_schema = pa.schema(
    [
        ("implant_id", pa.int64()),
        ("uniq", pa.string()),
        ("value", pa.int64()),
    ]
)

# add version
table.add_version(version="v2", uri=".../somepath/v2/", schema=new_schema)

# get all versions
table.get_versions()
# ["v1", "v2"] 

# switches to v1 table
table.change_version("v1")
```



Closes #42