### PR TITLE
Add batching support to fetch_df_by_partition for improved performance with large file counts

### DIFF
--- a/src/datarepo/core/tables/deltalake_table.py
+++ b/src/datarepo/core/tables/deltalake_table.py
@@ -402,7 +402,7 @@ def fetch_dfs_by_paths_batching(
         files (list[str]): List of file paths to read Parquet files from.
         schema (pa.Schema): Schema to normalize the dataframes to.
         storage_options (dict[str, Any] | None, optional): Storage options for reading the Parquet files, such as S3 access credentials. Defaults to None.
-        batch_size (int ): Number of files to process per batch.
+        batch_size (int): Number of files to process per batch.
 
     Returns:
         pl.DataFrame: A Polars DataFrame containing the concatenated results of all Parquet files, normalized to the specified schema.


### PR DESCRIPTION
Adds batching support to fetch_df_by_partition with use_batching and batch_size parameters. When enabled, files are processed in smaller batches instead of loading all files into memory simultaneously, which should reduce peak memory usage if users have extremely large file counts. Uses the existing fetch_dfs_by_paths_batching function. Maintains backward compatibility - existing code works unchanged.