### PR TITLE
Display user-specified operator in ParquetTable example docs_filters

### DIFF
--- a/src/datarepo/core/tables/metadata.py
+++ b/src/datarepo/core/tables/metadata.py
@@ -23,6 +23,7 @@ class TableMetadata:
 
 class TablePartition(TypedDict):
     column_name: str
+    operator: str
     type_annotation: str
     value: Any
 

--- a/src/datarepo/core/tables/parquet_table.py
+++ b/src/datarepo/core/tables/parquet_table.py
@@ -218,6 +218,7 @@ class ParquetTable(TableProtocol):
         partitions = [
             TablePartition(
                 column_name=filter.column,
+                operator=filter.operator,
                 type_annotation=type(filter.value).__name__,
                 value=filter.value,
             )

--- a/src/datarepo/export/static_site/src/lib/codegen.ts
+++ b/src/datarepo/export/static_site/src/lib/codegen.ts
@@ -74,7 +74,7 @@ export function genTableCode({ catalog, database, table, formatSqlFilter }: GenT
 
       for (const partition of table.partitions) {
         const value = isStringPartition(partition) ? `"${partition.value}"` : partition.value
-        filters.push(`Filter("${partition.column_name}", "=", ${value})`)
+        filters.push(`Filter("${partition.column_name}", "${partition.operator}", ${value})`)
       }
 
       /*

--- a/src/datarepo/export/static_site/src/lib/types.ts
+++ b/src/datarepo/export/static_site/src/lib/types.ts
@@ -1,5 +1,6 @@
 export interface ExportedTablePartition {
   column_name: string
+  operator: string
   type_annotation: string | null
   value: string | number
 }


### PR DESCRIPTION
When declaring ParquetTables, a filter could be passed into `docs_filters` with an operator other than `"="`, such as `"contains"`. However, the user-specified operator isn't passed through to the generated code examples on the static site, which hardcodes filters to display operator `"="`, creating confusion for users of the web catalog trying to properly query the data.

This passes the user-specified operator from table declaration through to the static site codegen.