### PR TITLE
Release version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "data-repository"
-version = "0.0.1"
+version = "0.0.2"
 description = "A simple platform for complex data"
 readme = "docs/README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Releasing new version, will include custom catalog naming to avoid forcing `from datarepo_catalogs` as the default. 