### PR TITLE
Add versioned schema access for DeltalakeTable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -46,6 +46,41 @@ part = DeltalakeTable(
 )
 ```
 
+#### Schema versioning
+When schema or business logic evolves, older data may remain at versioned URIs (for example `s3://my-bucket/tpc-h/part/v1`). Use `schema_versions` to bind each version label to a PyArrow schema and resolve reads to `{uri}/{version}`:
+
+```python
+v1_schema = pa.schema([
+    ("p_partkey", pa.int64()),
+    ("p_name", pa.string()),
+    ("p_size", pa.int32()),
+])
+
+v2_schema = pa.schema([
+    ("p_partkey", pa.int64()),
+    ("p_name", pa.string()),
+    ("p_size", pa.int32()),
+    ("p_comment", pa.string()),
+])
+
+part = DeltalakeTable(
+    name="part",
+    uri="s3://my-bucket/tpc-h/part",
+    schema=v2_schema,
+    schema_versions={"v1": v1_schema, "v2": v2_schema},
+    default_schema_version="v2",
+)
+
+# Latest schema (v2) from s3://my-bucket/tpc-h/part/v2
+>>> df_v2 = part()
+
+# Prior schema (v1) from s3://my-bucket/tpc-h/part/v1
+>>> df_v1 = part.at_version("v1")()
+>>> df_v1_inline = part(schema_version="v1")
+```
+
+Existing tables without `schema_versions` behave exactly as before.
+
 #### Parquet tables
 ```python
 from datarepo.core import ParquetTable, Partition, PartitioningScheme

--- a/src/datarepo/core/tables/deltalake_table.py
+++ b/src/datarepo/core/tables/deltalake_table.py
@@ -81,12 +81,16 @@ class DeltalakeTable(TableProtocol):
         table_metadata_args: dict[str, Any] | None = None,
         stats_cols: list[str] | None = None,
         extra_cols: list[tuple[pl.Expr, str]] | None = None,
+        schema_versions: dict[str, pa.Schema] | None = None,
+        default_schema_version: str | None = None,
     ):
         """Initialize the DeltalakeTable.
 
         Args:
             name (str): table name, used as the table identifier in the DeltaTable
-            uri (str): uri of the table, e.g. "s3://bucket/path/to/table"
+            uri (str): uri of the table, e.g. "s3://bucket/path/to/table". When
+                ``schema_versions`` is set, this is the base URI and each version
+                is read from ``{uri}/{version}``.
             schema (pa.Schema): schema of the table, used to define the table structure
             description (str, optional): description of the table, used for documentation. Defaults to "".
             docs_filters (list[Filter], optional): documentation filters, used to filter the table in the documentation. Defaults to [].
@@ -96,20 +100,101 @@ class DeltalakeTable(TableProtocol):
             table_metadata_args (dict[str, Any] | None, optional): table metadata arguments, used to configure the table metadata. Defaults to None.
             stats_cols (list[str] | None, optional): statistics columns, used to define the columns that have statistics. Defaults to None.
             extra_cols (list[tuple[pl.Expr, str]] | None, optional): extra columns to add to the table, where each tuple contains a Polars expression and its type annotation. Defaults to None.
+            schema_versions (dict[str, pa.Schema] | None, optional): optional map of
+                version labels (e.g. ``"v1"``, ``"v2"``) to schemas for tables stored
+                at versioned URIs. Defaults to None.
+            default_schema_version (str | None, optional): version label from
+                ``schema_versions`` used for the default read URI and schema. When
+                ``schema_versions`` is set and this is omitted, the key whose schema
+                equals ``schema`` is used. Defaults to None.
         """
         self.name = name
-        self.uri = uri
-        self.schema = schema
+        self._base_uri = uri.rstrip("/")
+        self.schema_versions = schema_versions
         self.unique_columns = unique_columns
         self.stats_cols = stats_cols or []
         self.extra_cols = extra_cols or []
+
+        if schema_versions:
+            if default_schema_version is not None:
+                if default_schema_version not in schema_versions:
+                    raise ValueError(
+                        f"default_schema_version {default_schema_version!r} is not in "
+                        f"schema_versions keys: {sorted(schema_versions)}"
+                    )
+                active_version = default_schema_version
+            else:
+                active_version = _schema_version_for_schema(schema, schema_versions)
+                if active_version is None:
+                    raise ValueError(
+                        "schema does not match any entry in schema_versions; "
+                        "pass default_schema_version explicitly"
+                    )
+            self._schema_version = active_version
+            self.schema = schema_versions[active_version]
+        else:
+            if default_schema_version is not None:
+                raise ValueError(
+                    "default_schema_version requires schema_versions to be set"
+                )
+            self._schema_version = None
+            self.schema = schema
+
+        self._table_metadata_args = table_metadata_args or {}
 
         self.table_metadata = TableMetadata(
             table_type="DELTA_LAKE",
             description=description,
             docs_args={"filters": docs_filters, "columns": docs_columns},
             roapi_opts=roapi_opts or DeltaRoapiOptions(),
-            **(table_metadata_args or {}),
+            **self._table_metadata_args,
+        )
+
+    @property
+    def uri(self) -> str:
+        """Resolved table URI, including the schema version suffix when applicable."""
+        if self._schema_version is not None and self.schema_versions is not None:
+            return f"{self._base_uri}/{self._schema_version}"
+        return self._base_uri
+
+    @property
+    def schema_version(self) -> str | None:
+        """Active schema version label, or None when versioning is disabled."""
+        return self._schema_version
+
+    def at_version(self, version: str) -> DeltalakeTable:
+        """Return a table bound to a specific schema version and URI suffix.
+
+        Args:
+            version (str): key from ``schema_versions`` (e.g. ``"v1"``).
+
+        Returns:
+            DeltalakeTable: a new table instance using the version's schema and URI.
+        """
+        if self.schema_versions is None:
+            raise ValueError(
+                "at_version() requires schema_versions to be set on DeltalakeTable"
+            )
+        if version not in self.schema_versions:
+            raise KeyError(
+                f"Unknown schema version {version!r}. "
+                f"Known versions: {sorted(self.schema_versions)}"
+            )
+
+        return DeltalakeTable(
+            name=self.name,
+            uri=self._base_uri,
+            schema=self.schema_versions[version],
+            description=self.table_metadata.description,
+            docs_filters=self.table_metadata.docs_args.get("filters", []),
+            docs_columns=self.table_metadata.docs_args.get("columns"),
+            roapi_opts=self.table_metadata.roapi_opts,
+            unique_columns=self.unique_columns,
+            table_metadata_args=self._table_metadata_args,
+            stats_cols=self.stats_cols,
+            extra_cols=self.extra_cols,
+            schema_versions=self.schema_versions,
+            default_schema_version=version,
         )
 
     def get_schema(self) -> TableSchema:
@@ -167,6 +252,8 @@ class DeltalakeTable(TableProtocol):
         endpoint_url: str | None = None,
         timeout: str | None = None,
         cache_options: DeltaCacheOptions | None = None,
+        schema_version: str | None = None,
+        delta_version: int | None = None,
         **kwargs: Any,
     ) -> NlkDataFrame:
         """Fetch a dataframe from the Delta Lake table.
@@ -178,10 +265,17 @@ class DeltalakeTable(TableProtocol):
             endpoint_url (str | None, optional): endpoint URL for S3 access. Defaults to None.
             timeout (str | None, optional): timeout for S3 access. Defaults to None.
             cache_options (DeltaCacheOptions | None, optional): cache options for the Delta Lake table. Defaults to None.
+            schema_version (str | None, optional): when ``schema_versions`` is configured,
+                read from ``{uri}/{schema_version}`` using that version's schema.
+                Defaults to None (use the table's bound version).
+            delta_version (int | None, optional): Delta Lake transaction log version for
+                time travel within the resolved table URI. Defaults to None (latest).
 
         Returns:
             NlkDataFrame: a dataframe containing the data from the Delta Lake table, filtered and selected according to the provided parameters.
         """
+        table = self.at_version(schema_version) if schema_version else self
+
         storage_options = {
             "timeout": timeout or DEFAULT_TIMEOUT,
             **get_storage_options(
@@ -193,9 +287,11 @@ class DeltalakeTable(TableProtocol):
                 **storage_options,
                 **cache_options.to_storage_options(),
             }
-        dt = self.delta_table(storage_options=storage_options)
+        dt = table.delta_table(
+            storage_options=storage_options, version=delta_version
+        )
 
-        return self.construct_df(dt=dt, filters=filters, columns=columns)
+        return table.construct_df(dt=dt, filters=filters, columns=columns)
 
     def construct_df(
         self,
@@ -420,6 +516,15 @@ def _normalize_df(
         .with_columns([pl.col(col).cast(dtype) for col, dtype in polars_schema.items()])
         .select(schema_columns)
     )
+
+
+def _schema_version_for_schema(
+    schema: pa.Schema, schema_versions: dict[str, pa.Schema]
+) -> str | None:
+    for version, version_schema in schema_versions.items():
+        if version_schema.equals(schema):
+            return version
+    return None
 
 
 def datafusion_predicate_from_filters(

--- a/test/tables/test_deltalake_table.py
+++ b/test/tables/test_deltalake_table.py
@@ -377,6 +377,109 @@ class TestDeltalakeTable:
         expected_sorted = expected.sort("value")
         assert actual_sorted.equals(expected_sorted)
 
+    def test_schema_version_uri_resolution(self):
+        v1_schema = pa.schema([("id", pa.int64()), ("value", pa.int64())])
+        v2_schema = pa.schema(
+            [("id", pa.int64()), ("value", pa.int64()), ("note", pa.string())]
+        )
+        table = DeltalakeTable(
+            name="signals",
+            uri="s3://bucket/neural/signals",
+            schema=v2_schema,
+            schema_versions={"v1": v1_schema, "v2": v2_schema},
+            default_schema_version="v2",
+        )
+
+        assert table.uri == "s3://bucket/neural/signals/v2"
+        assert table.schema_version == "v2"
+        assert table.at_version("v1").uri == "s3://bucket/neural/signals/v1"
+        assert table.at_version("v1").schema.equals(v1_schema)
+
+    def test_versioned_schema_reads(
+        self,
+        tmp_path: Path,
+    ):
+        base_path = tmp_path / "part"
+        v1_schema = pa.schema(
+            [
+                ("p_partkey", pa.int64()),
+                ("p_name", pa.string()),
+                ("p_size", pa.int32()),
+            ]
+        )
+        v2_schema = pa.schema(
+            [
+                ("p_partkey", pa.int64()),
+                ("p_name", pa.string()),
+                ("p_size", pa.int32()),
+                ("p_comment", pa.string()),
+            ]
+        )
+
+        v1_path = base_path / "v1"
+        v2_path = base_path / "v2"
+
+        v1_data = pl.DataFrame(
+            {
+                "p_partkey": [1, 2],
+                "p_name": ["a", "b"],
+                "p_size": [10, 20],
+            }
+        )
+        v2_data = pl.DataFrame(
+            {
+                "p_partkey": [1, 2],
+                "p_name": ["a", "b"],
+                "p_size": [10, 20],
+                "p_comment": ["old", "new"],
+            }
+        )
+
+        v1_table = DeltaTable.create(table_uri=str(v1_path), schema=v1_schema)
+        write_deltalake(v1_table, data=v1_data.to_arrow(), mode="overwrite")
+        v2_table = DeltaTable.create(table_uri=str(v2_path), schema=v2_schema)
+        write_deltalake(v2_table, data=v2_data.to_arrow(), mode="overwrite")
+
+        part = DeltalakeTable(
+            name="part",
+            uri=str(base_path),
+            schema=v2_schema,
+            schema_versions={"v1": v1_schema, "v2": v2_schema},
+            default_schema_version="v2",
+        )
+
+        v1_result = part.at_version("v1")().collect().sort("p_partkey")
+        assert list(v1_result.columns) == ["p_partkey", "p_name", "p_size"]
+        assert v1_result.equals(v1_data)
+
+        v2_result = part().collect().sort("p_partkey")
+        assert list(v2_result.columns) == [
+            "p_partkey",
+            "p_name",
+            "p_size",
+            "p_comment",
+        ]
+        assert v2_result.equals(v2_data)
+
+        inline_v1 = part(schema_version="v1").collect().sort("p_partkey")
+        assert inline_v1.equals(v1_data)
+
+    def test_at_version_requires_schema_versions(self, delta_table_definition):
+        with pytest.raises(ValueError, match="schema_versions"):
+            delta_table_definition.at_version("v1")
+
+    def test_unknown_schema_version_raises(self):
+        schema = pa.schema([("id", pa.int64())])
+        table = DeltalakeTable(
+            name="t",
+            uri="/tmp/t",
+            schema=schema,
+            schema_versions={"v1": schema},
+            default_schema_version="v1",
+        )
+        with pytest.raises(KeyError, match="v9"):
+            table.at_version("v9")
+
     """ this test is commented out until we upstream delta caching
     def test_delta_cache(
         self,


### PR DESCRIPTION
## Summary

- Adds `schema_versions` + `default_schema_version` to bind version labels (e.g. `v1`, `v2`) to PyArrow schemas and resolve reads to `{base_uri}/{version}`.
- Adds `at_version(version)` (immutable) and `schema_version=` on `__call__` for query-time selection.
- Exposes `delta_version=` on `__call__` for Delta Lake transaction-log time travel within a resolved URI.
- Fully backward compatible: tables without `schema_versions` behave exactly as before.

Closes #42

## API sketch

```python
part = DeltalakeTable(
    name="part",
    uri="s3://my-bucket/tpc-h/part",
    schema=v2_schema,
    schema_versions={"v1": v1_schema, "v2": v2_schema},
    default_schema_version="v2",
)

df_v1 = part.at_version("v1")()           # reads s3://.../part/v1 with v1 schema
df_v1_inline = part(schema_version="v1")  # same, inline override
```

## Design notes

- **Why immutable `at_version()`?** Catalog table definitions are typically declarative; returning a new bound instance avoids shared mutable state across callers.
- **Why URI suffix convention?** Matches the example in #42 (`s3://my-bucket/tpc-h/part/v1`).
- **Relation to #46:** Alternative to `add_version()` / `change_version()`; happy to consolidate if maintainers prefer that surface.

## Test plan

- [x] `pytest test/tables/test_deltalake_table.py -v` — 13/13 pass (includes v1/v2 integration test)
- [x] `pytest test/ --ignore=test/roapi -q` — 85/85 pass
- [x] Existing unversioned `DeltalakeTable` tests unchanged