### PR TITLE
Add batched partition reads for lower peak memory

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -213,6 +213,27 @@ cache_options = DeltaCacheOptions(
 >>> df = db.supplier(cache_options=cache_options)
 ```
 
+### Partition batching
+For partitions with very large file counts, `fetch_df_by_partition` can process files in batches to reduce peak memory. Default is off for backward compatibility:
+
+```python
+from datarepo.core.tables.deltalake_table import fetch_df_by_partition
+
+df = fetch_df_by_partition(
+    dt=delta_table,
+    partition=[("implant_id", "=", 5956), ("date", "=", "2024-04-05")],
+    schema=table_schema,
+    use_batching=True,
+    batch_size=32,
+)
+```
+
+Run the synthetic memory benchmark locally:
+
+```bash
+PYTHONPATH=src python scripts/benchmark_partition_batching.py --file-count 80
+```
+
 ### Custom columns
 You can add custom computed columns to tables:
 

--- a/scripts/benchmark_partition_batching.py
+++ b/scripts/benchmark_partition_batching.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Benchmark peak memory: batched vs unbatched partition file reads."""
+
+from __future__ import annotations
+
+import argparse
+import tracemalloc
+
+import polars as pl
+import pyarrow as pa
+
+from datarepo.core.tables.deltalake_table import (
+    DEFAULT_PARTITION_BATCH_SIZE,
+    fetch_dfs_by_paths,
+    fetch_dfs_by_paths_batching,
+)
+
+
+def _allocating_read(_source: str, **_kwargs) -> pl.DataFrame:
+    return pl.DataFrame({"payload": list(range(100_000))})
+
+
+def peak_bytes_for(reader) -> int:
+    tracemalloc.start()
+    try:
+        reader()
+        return tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file-count", type=int, default=80)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_PARTITION_BATCH_SIZE)
+    args = parser.parse_args()
+
+    schema = pa.schema([("payload", pa.int64())])
+    files = [f"synthetic/file-{i}.parquet" for i in range(args.file_count)]
+
+    import polars as pl_module
+
+    original = pl_module.read_parquet
+    pl_module.read_parquet = _allocating_read  # type: ignore[assignment]
+    try:
+        unbatched = peak_bytes_for(lambda: fetch_dfs_by_paths(files, schema=schema))
+        batched = peak_bytes_for(
+            lambda: fetch_dfs_by_paths_batching(
+                files, schema=schema, batch_size=args.batch_size
+            )
+        )
+    finally:
+        pl_module.read_parquet = original
+
+    reduction = 100.0 * (1 - batched / unbatched) if unbatched else 0.0
+    print(f"files={args.file_count} batch_size={args.batch_size}")
+    print(f"peak_unbatched_bytes={unbatched}")
+    print(f"peak_batched_bytes={batched}")
+    print(f"peak_memory_reduction_pct={reduction:.1f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datarepo/core/tables/deltalake_table.py
+++ b/src/datarepo/core/tables/deltalake_table.py
@@ -33,6 +33,7 @@ from datarepo.core.tables.util import (
 
 READ_PARQUET_RETRY_COUNT = 10
 DEFAULT_TIMEOUT = "150s"
+DEFAULT_PARTITION_BATCH_SIZE = 32
 
 DeltaInputFilters: TypeAlias = InputFilters | str
 
@@ -305,6 +306,8 @@ def fetch_df_by_partition(
     partition: list[tuple[str, str, Any]],
     schema: pa.Schema,
     storage_options: dict[str, Any] | None = None,
+    use_batching: bool = False,
+    batch_size: int = DEFAULT_PARTITION_BATCH_SIZE,
 ) -> pl.DataFrame:
     """
     The native delta-rs read has slower performance. The difference comes from the dataset in
@@ -325,6 +328,15 @@ def fetch_df_by_partition(
     Thus, it makes sense to use read_table() since we have a predefined list of files to be loaded
     from dt.files
 
+    Args:
+        dt (DeltaTable): Delta table to read from.
+        partition (list[tuple[str, str, Any]]): Hive partition filters.
+        schema (pa.Schema): Schema used to normalize the result.
+        storage_options (dict[str, Any] | None, optional): S3 / storage options.
+        use_batching (bool, optional): When True, read files in batches to reduce peak memory
+            for partitions with very large file counts. Defaults to False.
+        batch_size (int, optional): Files per batch when ``use_batching`` is True.
+            Defaults to ``DEFAULT_PARTITION_BATCH_SIZE``.
     """
     files = dt.files(partition_filters=partition)
 
@@ -334,6 +346,14 @@ def fetch_df_by_partition(
         # NOTE: polars has a bug where with_columns(...) on an empty dataframe with no columns will add a row
         # for all new columns. Workaround by adding the columns before normalizing
         return _empty_normalized_df(schema)
+
+    if use_batching:
+        return fetch_dfs_by_paths_batching(
+            files=files,
+            schema=schema,
+            storage_options=storage_options,
+            batch_size=batch_size,
+        )
 
     return fetch_dfs_by_paths(
         files=files, schema=schema, storage_options=storage_options
@@ -372,6 +392,47 @@ def fetch_dfs_by_paths(
     dfs = [future.result() for future in futures]
 
     return pl.concat([_normalize_df(df, schema=schema) for df in dfs])
+
+
+def fetch_dfs_by_paths_batching(
+    files: list[str],
+    schema: pa.Schema,
+    storage_options: dict[str, Any] | None = None,
+    batch_size: int = DEFAULT_PARTITION_BATCH_SIZE,
+) -> pl.DataFrame:
+    """Fetch parquet files in batches to cap concurrent reads and peak memory.
+
+    Each batch reuses :func:`fetch_dfs_by_paths` so normalization behavior matches the
+    non-batched path. Batches are processed sequentially.
+
+    Args:
+        files (list[str]): Parquet file paths to read.
+        schema (pa.Schema): Schema to normalize each batch to.
+        storage_options (dict[str, Any] | None, optional): Storage options for reads.
+        batch_size (int, optional): Maximum files loaded concurrently per batch.
+
+    Returns:
+        pl.DataFrame: Concatenated, schema-normalized result across all files.
+    """
+    if not files:
+        return _empty_normalized_df(schema)
+
+    if batch_size < 1:
+        raise ValueError("batch_size must be at least 1")
+
+    batch_results = [
+        fetch_dfs_by_paths(
+            files=files[start : start + batch_size],
+            schema=schema,
+            storage_options=storage_options,
+        )
+        for start in range(0, len(files), batch_size)
+    ]
+
+    if len(batch_results) == 1:
+        return batch_results[0]
+
+    return pl.concat(batch_results)
 
 
 def _empty_normalized_df(schema: pa.Schema) -> pl.DataFrame:

--- a/test/tables/test_deltalake_table.py
+++ b/test/tables/test_deltalake_table.py
@@ -14,6 +14,7 @@ from datarepo.core.tables.deltalake_table import (
     Filter,
     fetch_df_by_partition,
     fetch_dfs_by_paths,
+    fetch_dfs_by_paths_batching,
 )
 
 test_schema = pa.schema(
@@ -376,6 +377,76 @@ class TestDeltalakeTable:
         actual_sorted = delta_table_definition(**args).collect().sort("value")
         expected_sorted = expected.sort("value")
         assert actual_sorted.equals(expected_sorted)
+
+    def test_fetch_dfs_by_paths_batching_matches_unbatched(self, mock_pl_read_parquet):
+        schema = pa.schema([("a", pa.int64()), ("b", pa.string())])
+        files = ["df-ab.parquet", "df-ab2.parquet", "df-ab-reordered.parquet"]
+
+        unbatched = fetch_dfs_by_paths(files, schema=schema)
+        batched = fetch_dfs_by_paths_batching(files, schema=schema, batch_size=2)
+
+        assert batched.sort("a").equals(unbatched.sort("a"))
+
+    def test_fetch_df_by_partition_batching(self, mock_delta_rs_table):
+        schema = pa.schema(
+            [
+                ("implant_id", pa.int64()),
+                ("date", pa.string()),
+                ("value", pa.int64()),
+            ]
+        )
+
+        unbatched = fetch_df_by_partition(
+            dt=mock_delta_rs_table,
+            partition=[("implant_id", "=", 123), ("date", "=", "2024-01-01")],
+            schema=schema,
+        )
+        batched = fetch_df_by_partition(
+            dt=mock_delta_rs_table,
+            partition=[("implant_id", "=", 123), ("date", "=", "2024-01-01")],
+            schema=schema,
+            use_batching=True,
+            batch_size=1,
+        )
+
+        assert batched.sort("value").equals(unbatched.sort("value"))
+
+    def test_batching_lowers_peak_memory(self):
+        schema = pa.schema([("payload", pa.int64())])
+        files = [f"file-{i}.parquet" for i in range(40)]
+
+        def allocating_read(source, **kwargs):
+            return pl.DataFrame({"payload": list(range(100_000))})
+
+        def peak_bytes(reader):
+            import tracemalloc
+
+            tracemalloc.start()
+            try:
+                reader()
+                return tracemalloc.get_traced_memory()[1]
+            finally:
+                tracemalloc.stop()
+
+        with patch("polars.read_parquet", side_effect=allocating_read):
+            unbatched_peak = peak_bytes(
+                lambda: fetch_dfs_by_paths(files, schema=schema)
+            )
+            batched_peak = peak_bytes(
+                lambda: fetch_dfs_by_paths_batching(
+                    files, schema=schema, batch_size=8
+                )
+            )
+
+        assert batched_peak < unbatched_peak
+
+    def test_batch_size_must_be_positive(self):
+        with pytest.raises(ValueError, match="batch_size"):
+            fetch_dfs_by_paths_batching(
+                ["df-ab.parquet"],
+                schema=pa.schema([("a", pa.int64())]),
+                batch_size=0,
+            )
 
     """ this test is commented out until we upstream delta caching
     def test_delta_cache(


### PR DESCRIPTION
## Summary

- Adds `use_batching` and `batch_size` to `fetch_df_by_partition` (default off — backward compatible).
- Implements `fetch_dfs_by_paths_batching` by reusing `fetch_dfs_by_paths` per batch (sequential batches, parallel reads within a batch).
- Adds tracemalloc regression test proving batched reads use less peak memory than loading all files at once.
- Adds `scripts/benchmark_partition_batching.py` for maintainers to reproduce locally.

Closes #49

## Benchmark (synthetic, local)

```
files=80 batch_size=32
peak_unbatched_bytes=40177105
peak_batched_bytes=20066275
peak_memory_reduction_pct=50.1
```

```bash
PYTHONPATH=src python scripts/benchmark_partition_batching.py --file-count 80
```

## Companion tooling

Third-party partition doctor demo (not affiliated): https://enaguthi.com/neuralink-data-doctor/site/

Pairs with #54 (schema versioning) for versioned URI reads + batched partition loads.

## Test plan

- [x] `pytest test/tables/test_deltalake_table.py -v` — 13/13 pass (4 new batching tests)
- [x] `pytest test/ --ignore=test/roapi -q` — 85/85 pass