### PR TITLE
Declare Python 3.10 minimum and verify installed wheels

### DIFF
--- a/.github/workflows/installed-wheel-smoke.yml
+++ b/.github/workflows/installed-wheel-smoke.yml
@@ -1,0 +1,39 @@
+name: Installed wheel smoke
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  installed-wheel:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12']
+    env:
+      AWS_EC2_METADATA_DISABLED: 'true'
+      POLARS_MAX_THREADS: '2'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build the wheel including the static catalog
+        run: |
+          python -m pip install build
+          python -m build --wheel
+      - name: Install and read local data outside the checkout
+        shell: bash
+        run: |
+          wheel_env="$RUNNER_TEMP/datarepo-wheel-smoke"
+          python -m venv "$wheel_env"
+          "$wheel_env/bin/python" -m pip install dist/*.whl
+          cd "$RUNNER_TEMP"
+          "$wheel_env/bin/python" -I "$GITHUB_WORKSPACE/scripts/smoke_installed_wheel.py"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,18 @@
+# Python compatibility
+
+The minimum Python version is 3.10. Runtime type aliases use the union operator,
+and Python 3.9 fails while importing `datarepo.core.tables.filters` even after
+its dependencies install. The existing Python 3.8 declaration also cannot
+resolve a binary-wheel environment for the required Delta Lake versions on
+the tested Linux x86-64 host. These are distinct failures.
+
+The installed-wheel smoke workflow builds the package, including its static
+catalog, then installs into a fresh environment and reads a local Parquet table
+with Python 3.10 and 3.12 on Ubuntu 24.04. It runs with `python -I` outside the
+source directory and verifies the package comes from `site-packages`.
+
+Building from source needs Python build tooling, Node.js and npm because the
+existing Hatch hook compiles the web catalog. The dependency caps for Polars
+and Delta Lake are unchanged. This check covers installation, import, and one
+local table read; it does not establish every backend or platform combination.
+Other Python versions, Windows and macOS are not validated by this Linux job.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "data-repository"
 version = "0.1.0"
 description = "A simple platform for complex data"
 readme = "docs/README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [
     { name = "Gautham Acharya", email = "gautacharya@gmail.com" }

--- a/scripts/smoke_installed_wheel.py
+++ b/scripts/smoke_installed_wheel.py
@@ -1,0 +1,38 @@
+"""Run with python -I from outside the checkout after installing a built wheel."""
+
+import json
+from pathlib import Path
+import platform
+import sys
+from tempfile import TemporaryDirectory
+
+import polars as pl
+import datarepo
+from datarepo.core import Filter, ParquetTable
+
+
+origin = Path(datarepo.__file__).resolve()
+if "site-packages" not in origin.parts:
+    raise AssertionError(f"Expected a wheel installation, imported {origin}")
+with TemporaryDirectory(prefix="datarepo-wheel-smoke-") as directory:
+    path = Path(directory) / "example.parquet"
+    pl.DataFrame({"id": [1, 2, 3], "value": [10, 20, 30]}).write_parquet(path)
+    table = ParquetTable(name="example", uri=str(path), partitioning=[])
+    result = (
+        table(filters=[Filter("value", ">", 10)], columns=["id", "value"])
+        .collect()
+        .sort("id")
+    )
+    assert result.to_dicts() == [{"id": 2, "value": 20}, {"id": 3, "value": 30}]
+    assert result.schema == {"id": pl.Int64, "value": pl.Int64}
+print(
+    json.dumps(
+        {
+            "python": platform.python_version(),
+            "isolated": bool(sys.flags.isolated),
+            "imported_from": str(origin),
+            "rows": result.to_dicts(),
+        },
+        indent=2,
+    )
+)


### PR DESCRIPTION
The declared Python 3.8 minimum does not describe the tested install/import
behavior. Linux x86-64 dependency resolution with required wheels fails for 3.8
at Delta Lake. Python 3.9 resolves and installs those dependencies, then fails
importing the runtime union alias in `datarepo.core.tables.filters`.

Propose a Python 3.10 minimum and add a read-only wheel smoke workflow for 3.10
and 3.12 on Ubuntu 24.04. It includes the existing Node/npm static-catalog build,
installs the built wheel into a new venv, and uses `python -I` outside the checkout
to assert the module comes from site-packages and reads/filters local Parquet.
Polars and Delta Lake caps remain unchanged.

Refreshed against upstream main `74ffaa2f70bcdfa863406ef1525b6d5a050b0204`, preserving this PR's independent scope. Published head: `f7eb0866df47dc66612dea4e520a62e73db9e308`; tree: `32423498364bc085735ac431686ad1038683aafa`.

[Upstream checks on the refreshed head](https://github.com/neuralinkcorp/datarepo/pull/59/checks) pass: repository tests, code quality, and installed-wheel smoke on Python 3.10 and 3.12. Each smoke builds the bundled static catalog, installs in a fresh environment, imports from `site-packages` using isolated Python, and verifies the local Parquet result. This does not certify every backend, platform, or Python version.

Raising the Python minimum is a proposed support-policy change for maintainer
review. If 3.8/3.9 support is required, runtime typing and dependency compatibility
need a separate repair; the measured failure should not be hidden by the metadata.

Developed with AI assistance. Maintainer edits are enabled. This PR can be reviewed
after the independent correctness fix without blocking it.

**Evidence access:** Contributor logs, screenshots and detailed reports are private. The contributor validation counts are self-reported; source and test changes remain available in this PR. Linked upstream results are separate.
