### PR TITLE
Fix code review bot login for GitHub App tokens

### DIFF
--- a/.github/scripts/code_review.py
+++ b/.github/scripts/code_review.py
@@ -435,6 +435,24 @@ def configured(env: Mapping[str, str]) -> bool:
     return all(env.get(name) for name in REQUIRED_SECRETS)
 
 
+def resolve_bot_login(env: Mapping[str, str], github: GitHubClient) -> str:
+    """Installation tokens cannot call GET /user; use the App slug instead."""
+    explicit = (env.get("REVIEW_BOT_LOGIN") or "").strip()
+    if explicit:
+        return explicit
+    slug = (env.get("APP_SLUG") or "").strip()
+    if slug:
+        return slug if slug.lower().endswith("[bot]") else f"{slug}[bot]"
+    try:
+        data = github.graphql("query { viewer { login } }")
+        login = ((data or {}).get("viewer") or {}).get("login") or ""
+        if login:
+            return login
+    except Exception as exc:
+        LOGGER.warning("could not resolve bot login via graphql: %s", exc)
+    return "code-review-bot[bot]"
+
+
 def parse_resolved_ids(raw: Any, count: int) -> list[int]:
     ids: list[int] = []
     seen: set[int] = set()
@@ -664,8 +682,7 @@ def run(
         return "skip: no pull request associated with this workflow run"
 
     pr = github.get_json(f"/repos/{github.repo}/pulls/{number}")
-    me = github.get_json("/user")
-    bot_login = me.get("login") or "code-review-bot[bot]"
+    bot_login = resolve_bot_login(env, github)
     head_sha = (
         (pr.get("head") or {}).get("sha") or workflow_run(event).get("head_sha") or ""
     )

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -65,6 +65,7 @@ jobs:
         if: steps.cfg.outputs.configured == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           MODEL_API_KEY: ${{ secrets.MODEL_API_KEY }}
           MODEL: ${{ secrets.MODEL }}
           MODEL_API_URL: ${{ secrets.MODEL_API_URL }}

--- a/test/test_code_review.py
+++ b/test/test_code_review.py
@@ -79,7 +79,6 @@ PR_ROUTES = {
         "user": {"login": "zack-dev-cm"},
         "head": {"sha": "abc"},
     },
-    "/user": {"login": "code-review-bot[bot]"},
     "/repos/neuralinkcorp/datarepo/pulls/12/reviews": [],
     "/repos/neuralinkcorp/datarepo/pulls/12/files": [
         {
@@ -266,6 +265,19 @@ def test_skip_draft_and_existing_review(reviewer):
         head_sha="aaa",
     )
     assert own and "review bot" in own
+
+
+def test_resolve_bot_login_prefers_env_then_slug(reviewer):
+    github = FakeGitHub({})
+    assert (
+        reviewer.resolve_bot_login({"REVIEW_BOT_LOGIN": "custom[bot]"}, github)
+        == "custom[bot]"
+    )
+    assert (
+        reviewer.resolve_bot_login({"APP_SLUG": "neuralink-code-review-bot"}, github)
+        == "neuralink-code-review-bot[bot]"
+    )
+    assert reviewer.resolve_bot_login({}, github) == "code-review-bot[bot]"
 
 
 def test_run_skips_without_secrets(reviewer):


### PR DESCRIPTION
GitHub App installation tokens cannot call `GET /user` (`Resource not accessible by integration`). That is what failed on the #61 smoke run.

This takes the bot login from `actions/create-github-app-token`'s `app-slug` output (`<slug>[bot]`), with a GraphQL `viewer` fallback.

Needed on `main` before the code review workflow can succeed — `workflow_run` always runs the default-branch script.
