### PR TITLE
Pass filter operators through catalog export

### DIFF
--- a/src/datarepo/core/tables/decorator.py
+++ b/src/datarepo/core/tables/decorator.py
@@ -58,6 +58,7 @@ class FunctionTable(TableProtocol):
         partitions = [
             TablePartition(
                 column_name=filter.column,
+                operator=filter.operator,
                 type_annotation=type(filter.value).__name__,
                 value=filter.value,
             )

--- a/src/datarepo/core/tables/deltalake_table.py
+++ b/src/datarepo/core/tables/deltalake_table.py
@@ -158,15 +158,16 @@ class DeltalakeTable(TableProtocol):
 
         schema = self.schema
         filters = {
-            f.column: f.value
+            f.column: f
             for f in self.table_metadata.docs_args.get("filters", [])
             if isinstance(f, Filter)
         }
         partitions = [
             TablePartition(
                 column_name=col,
+                operator=filters[col].operator if col in filters else "=",
                 type_annotation=str(schema.field(col).type),
-                value=filters.get(col),
+                value=filters[col].value if col in filters else None,
             )
             for col in partition_cols
         ]

--- a/src/datarepo/core/tables/metadata.py
+++ b/src/datarepo/core/tables/metadata.py
@@ -23,6 +23,7 @@ class TableMetadata:
 
 class TablePartition(TypedDict):
     column_name: str
+    operator: str
     type_annotation: str
     value: Any
 

--- a/src/datarepo/core/tables/parquet_table.py
+++ b/src/datarepo/core/tables/parquet_table.py
@@ -224,6 +224,7 @@ class ParquetTable(TableProtocol):
         partitions = [
             TablePartition(
                 column_name=filter.column,
+                operator=filter.operator,
                 type_annotation=type(filter.value).__name__,
                 value=filter.value,
             )

--- a/src/datarepo/export/static_site/src/lib/codegen.ts
+++ b/src/datarepo/export/static_site/src/lib/codegen.ts
@@ -47,6 +47,22 @@ function isStringPartition(partition: ExportedTablePartition): boolean {
   return partition.type_annotation === 'str' || partition.type_annotation === 'string';
 }
 
+function partitionOperator(partition: ExportedTablePartition): string {
+  return partition.operator || '='
+}
+
+function formatSqlPredicate(partition: ExportedTablePartition): string {
+  const operator = partitionOperator(partition)
+  if (operator === 'is null' || operator === 'is not null') {
+    return `${partition.column_name} ${operator}`
+  }
+  if (operator === 'contains') {
+    return `${partition.column_name} like '%${partition.value}%'`
+  }
+  const value = isStringPartition(partition) ? `'${partition.value}'` : partition.value
+  return `${partition.column_name} ${operator} ${value}`
+}
+
 interface GenTableCodeOptions {
   catalog: ExportedCatalog;
   database: ExportedDatabase;
@@ -64,17 +80,14 @@ export function genTableCode({ catalog, database, table, formatSqlFilter }: GenT
 
   if (table.partitions.length !== 0) {
     if (formatSqlFilter) {
-      const stringFilter = table.partitions.map((partition) => {
-        const partitionValue = isStringPartition(partition) ? `'${partition.value}'` : partition.value;
-        return `${partition.column_name} = ${partitionValue}`
-      }).join(' and ');
+      const stringFilter = table.partitions.map(formatSqlPredicate).join(' and ');
       params.push(`filters="${stringFilter}"`);
     } else {
       const filters = []
 
       for (const partition of table.partitions) {
         const value = isStringPartition(partition) ? `"${partition.value}"` : partition.value
-        filters.push(`Filter("${partition.column_name}", "=", ${value})`)
+        filters.push(`Filter("${partition.column_name}", "${partitionOperator(partition)}", ${value})`)
       }
 
       /*

--- a/src/datarepo/export/static_site/src/lib/codegen.ts
+++ b/src/datarepo/export/static_site/src/lib/codegen.ts
@@ -63,6 +63,19 @@ function formatSqlPredicate(partition: ExportedTablePartition): string {
   return `${partition.column_name} ${operator} ${value}`
 }
 
+function formatFilterValue(partition: ExportedTablePartition): string {
+  const operator = partitionOperator(partition)
+  if (
+    operator === 'is null' ||
+    operator === 'is not null' ||
+    partition.value === null ||
+    partition.value === undefined
+  ) {
+    return 'None'
+  }
+  return isStringPartition(partition) ? `"${partition.value}"` : `${partition.value}`
+}
+
 interface GenTableCodeOptions {
   catalog: ExportedCatalog;
   database: ExportedDatabase;
@@ -86,8 +99,9 @@ export function genTableCode({ catalog, database, table, formatSqlFilter }: GenT
       const filters = []
 
       for (const partition of table.partitions) {
-        const value = isStringPartition(partition) ? `"${partition.value}"` : partition.value
-        filters.push(`Filter("${partition.column_name}", "${partitionOperator(partition)}", ${value})`)
+        filters.push(
+          `Filter("${partition.column_name}", "${partitionOperator(partition)}", ${formatFilterValue(partition)})`
+        )
       }
 
       /*

--- a/src/datarepo/export/static_site/src/lib/types.ts
+++ b/src/datarepo/export/static_site/src/lib/types.ts
@@ -2,7 +2,7 @@ export interface ExportedTablePartition {
   column_name: string
   operator?: string
   type_annotation: string | null
-  value: string | number
+  value: string | number | null
 }
 
 export interface ExportedTableColumn {

--- a/src/datarepo/export/static_site/src/lib/types.ts
+++ b/src/datarepo/export/static_site/src/lib/types.ts
@@ -1,5 +1,6 @@
 export interface ExportedTablePartition {
   column_name: string
+  operator?: string
   type_annotation: string | null
   value: string | number
 }

--- a/src/datarepo/export/web.py
+++ b/src/datarepo/export/web.py
@@ -35,19 +35,28 @@ def _schema_from_attribute(
 
     table_info = table.table_metadata
     docs_filters = table_info.docs_args.get("filters", [])
-    filter_values = {f.column: f.value for f in docs_filters if isinstance(f, Filter)}
+    docs_filter_by_column = {f.column: f for f in docs_filters if isinstance(f, Filter)}
     partition_columns = getattr(table, "partition_columns", None)
     if partition_columns is not None:
         partition_col_names = list(partition_columns)
     else:
-        partition_col_names = list(filter_values.keys())
+        partition_col_names = list(docs_filter_by_column.keys())
     stats_cols = getattr(table, "stats_cols", [])
 
     partitions = [
         TablePartition(
             column_name=col,
+            operator=(
+                docs_filter_by_column[col].operator
+                if col in docs_filter_by_column
+                else "="
+            ),
             type_annotation=str(schema.field(col).type),
-            value=filter_values.get(col),
+            value=(
+                docs_filter_by_column[col].value
+                if col in docs_filter_by_column
+                else None
+            ),
         )
         for col in partition_col_names
         if col in schema.names

--- a/test/export/test_web.py
+++ b/test/export/test_web.py
@@ -1,8 +1,13 @@
+from pathlib import Path
+
+import polars as pl
 import pytest
 import pyarrow as pa
 
 from datarepo.core.tables.clickhouse_table import ClickHouseTable, ClickHouseTableConfig
+from datarepo.core.tables.decorator import table
 from datarepo.core.tables.deltalake_table import DeltalakeTable
+from datarepo.core.tables.parquet_table import ParquetTable
 from datarepo.core.tables.util import Filter
 from datarepo.export.web import export_table
 
@@ -87,6 +92,7 @@ class TestWebExport:
         partition_names = [p["column_name"] for p in exported["partitions"]]
         assert partition_names == ["implant_id", "date", "hour"]
         assert exported["partitions"][0]["value"] == 12345
+        assert [p["operator"] for p in exported["partitions"]] == ["=", "=", "="]
 
     def test_export_table_delta_without_docs_filters(self):
         """Test that export_table works for delta tables without docs_filters."""
@@ -135,3 +141,127 @@ class TestWebExport:
         assert partition_names == ["implant_id", "date"]
         assert exported["partitions"][0]["value"] == 12345
         assert exported["partitions"][1]["value"] == "2025-07-21"
+        assert [p["operator"] for p in exported["partitions"]] == ["=", "="]
+
+    def test_export_table_preserves_docs_filter_operator(self):
+        table = DeltalakeTable(
+            name="test_delta",
+            uri="s3://fake-bucket/test/table",
+            schema=pa.schema(
+                [
+                    ("p_name", pa.string()),
+                    ("p_size", pa.int32()),
+                ]
+            ),
+            docs_filters=[
+                Filter("p_name", "contains", "Brand"),
+                Filter("p_size", ">=", 10),
+            ],
+        )
+
+        exported = export_table("test_delta", table)
+
+        assert [
+            (p["column_name"], p["operator"], p["value"])
+            for p in exported["partitions"]
+        ] == [
+            ("p_name", "contains", "Brand"),
+            ("p_size", ">=", 10),
+        ]
+
+    def test_export_clickhouse_preserves_docs_filter_operator(self, clickhouse_config):
+        clickhouse_table = ClickHouseTable(
+            name="test_table",
+            schema=pa.schema(
+                [
+                    ("str_value", pa.string()),
+                    ("value", pa.int64()),
+                ]
+            ),
+            config=clickhouse_config,
+            docs_filters=[Filter("str_value", "contains", "abc")],
+        )
+
+        exported = export_table("test_table", clickhouse_table)
+
+        assert exported["partitions"] == [
+            {
+                "column_name": "str_value",
+                "operator": "contains",
+                "type_annotation": "string",
+                "value": "abc",
+            }
+        ]
+
+    def test_export_parquet_preserves_docs_filter_operator(self, tmp_path: Path):
+        path = tmp_path / "example.parquet"
+        pl.DataFrame({"id": [1, 2], "name": ["acme", "other"]}).write_parquet(path)
+        parquet_table = ParquetTable(
+            name="example",
+            uri=str(path),
+            partitioning=[],
+            docs_filters=[Filter("name", "contains", "acme")],
+        )
+
+        exported = export_table("example", parquet_table)
+
+        assert exported["partitions"][0]["column_name"] == "name"
+        assert exported["partitions"][0]["operator"] == "contains"
+        assert exported["partitions"][0]["value"] == "acme"
+
+    def test_export_function_table_preserves_docs_filter_operator(self):
+        @table(docs_args={"filters": [Filter("name", "contains", "acme")]})
+        def suppliers():
+            return pl.LazyFrame({"name": ["acme", "other"]})
+
+        exported = export_table("suppliers", suppliers)
+
+        assert exported["partitions"][0]["column_name"] == "name"
+        assert exported["partitions"][0]["operator"] == "contains"
+        assert exported["partitions"][0]["value"] == "acme"
+
+    def test_delta_get_schema_preserves_docs_filter_operator(self):
+        delta_table = DeltalakeTable(
+            name="test_delta",
+            uri="s3://fake-bucket/test/table",
+            schema=pa.schema(
+                [
+                    ("implant_id", pa.int64()),
+                    ("date", pa.string()),
+                ]
+            ),
+            partition_columns=["implant_id", "date"],
+            docs_filters=[Filter("implant_id", ">=", 1)],
+        )
+
+        schema = delta_table.get_schema()
+
+        assert [
+            (p["column_name"], p["operator"], p["value"]) for p in schema.partitions
+        ] == [
+            ("implant_id", ">=", 1),
+            ("date", "=", None),
+        ]
+
+    def test_export_partition_without_docs_filter_defaults_to_equality(self):
+        delta_table = DeltalakeTable(
+            name="test_delta",
+            uri="s3://fake-bucket/test/table",
+            schema=pa.schema(
+                [
+                    ("implant_id", pa.int64()),
+                    ("date", pa.string()),
+                ]
+            ),
+            partition_columns=["implant_id", "date"],
+        )
+
+        exported = export_table("test_delta", delta_table)
+
+        assert [
+            (p["column_name"], p["operator"], p["value"])
+            for p in exported["partitions"]
+        ] == [
+            ("implant_id", "=", None),
+            ("date", "=", None),
+        ]


### PR DESCRIPTION
Catalog example codegen always emitted `Filter(..., "=", ...)` and SQL `column = value`, even when `docs_filters` used another operator.

Thread `Filter.operator` through `TablePartition` and every export path (Parquet, Delta, ClickHouse, function tables). SQL examples interpolate the operator; `is null` / `is not null` omit a value; `contains` becomes DataFusion `like`.

Supersedes #50.
