### PR TITLE
Raise code review timeout to 15 minutes

### DIFF
--- a/.github/scripts/code_review.py
+++ b/.github/scripts/code_review.py
@@ -31,6 +31,7 @@ MAX_DIFF_CHARS = 200_000
 MAX_INLINE_COMMENTS = 8
 MAX_COMMENT_CHARS = 8_000
 MAX_PREVIOUS_COMMENTS = 30
+MODEL_TIMEOUT_SECONDS = 15 * 60
 REVIEW_EVENT = "COMMENT"
 FOOTER = (
     "*Posted by the code review bot. This is an automated review, "
@@ -607,7 +608,11 @@ def build_user_prompt(
 
 
 def complete_chat(
-    api_key: str, model: str, system: str, user: str, timeout: int = 120
+    api_key: str,
+    model: str,
+    system: str,
+    user: str,
+    timeout: int = MODEL_TIMEOUT_SECONDS,
 ) -> str:
     api_url = os.environ.get("MODEL_API_URL")
     if not api_url:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -28,7 +28,7 @@ jobs:
   review:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 17
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -28,7 +28,7 @@ jobs:
   review:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The review step was aborting at the 120s urllib timeout (`The read operation timed out`) while the model was still generating. Successful reviews of other PRs were already taking 90–110s.

- Model HTTP timeout: 15 minutes
- Job `timeout-minutes`: 17, so checkout, App token minting, and GitHub API calls are not killed at the same wall clock as the model call
